### PR TITLE
Deploy after release

### DIFF
--- a/.changeset/six-stingrays-move.md
+++ b/.changeset/six-stingrays-move.md
@@ -1,0 +1,5 @@
+---
+"baseplate-cloudflare-worker": patch
+---
+
+Require Github release before deploying to customer-facing envs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,21 +34,3 @@ jobs:
       envName: dev
     secrets:
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-
-  deploy-test:
-    needs: deploy-dev
-    if: github.ref == 'refs/heads/main'
-    uses: JustUtahCoders/baseplate-cloudflare-worker/.github/workflows/deploy.yaml@main
-    with:
-      envName: test
-    secrets:
-      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-
-  deploy-prod:
-    needs: deploy-test
-    if: github.ref == 'refs/heads/main'
-    uses: JustUtahCoders/baseplate-cloudflare-worker/.github/workflows/deploy.yaml@main
-    with:
-      envName: prod
-    secrets:
-      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/new_tag.yaml
+++ b/.github/workflows/new_tag.yaml
@@ -1,0 +1,20 @@
+name: Release New Tag
+on:
+  release:
+    types: [published]
+jobs:
+  deploy-test:
+    needs: deploy-dev
+    uses: JustUtahCoders/baseplate-cloudflare-worker/.github/workflows/deploy.yaml@main
+    with:
+      envName: test
+    secrets:
+      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+
+  deploy-prod:
+    needs: deploy-test
+    uses: JustUtahCoders/baseplate-cloudflare-worker/.github/workflows/deploy.yaml@main
+    with:
+      envName: prod
+    secrets:
+      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
Release notes will show up in audit trails, so we need to ensure that we've created a Github release before every deployment to a customer facing env