### PR TITLE
Add single-spa dependencies to import map in html files

### DIFF
--- a/.changeset/fair-rocks-sell.md
+++ b/.changeset/fair-rocks-sell.md
@@ -1,0 +1,5 @@
+---
+"baseplate-cloudflare-worker": patch
+---
+
+Add necessary dependencies to web app import maps

--- a/src/__snapshots__/handleIndexHtml.test.ts.snap
+++ b/src/__snapshots__/handleIndexHtml.test.ts.snap
@@ -11,7 +11,10 @@ exports[`handleIndexHtml can render a SystemJS + single-spa root config 1`] = `
   <!-- Import Map URL: https://cdn.baseplate.cloud/convex/prod/test.importmap  -->
   <script type=\\"systemjs-importmap\\">
     {
-  \\"imports\\": {},
+  \\"imports\\": {
+    \\"single-spa\\": \\"https://cdn.jsdelivr.net/npm/single-spa@6.0.0/lib/es2015/system/single-spa.dev.min.js\\",
+    \\"single-spa-layout\\": \\"https://cdn.jsdelivr.net/npm/single-spa-layout@2.2.0/dist/system/single-spa-layout.min.js\\"
+  },
   \\"scopes\\": {}
 }
   </script>
@@ -98,7 +101,10 @@ exports[`handleIndexHtml can render a native module + single-spa root config 1`]
   <!-- Import Map URL: https://cdn.baseplate.cloud/convex/prod/test.importmap  -->
   <script type=\\"systemjs-importmap\\">
     {
-  \\"imports\\": {},
+  \\"imports\\": {
+    \\"single-spa\\": \\"https://cdn.jsdelivr.net/npm/single-spa@6.0.0/lib/es2015/system/single-spa.dev.min.js\\",
+    \\"single-spa-layout\\": \\"https://cdn.jsdelivr.net/npm/single-spa-layout@2.2.0/dist/system/single-spa-layout.min.js\\"
+  },
   \\"scopes\\": {}
 }
   </script>
@@ -186,7 +192,10 @@ exports[`handleIndexHtml default index.html matches snapshot 2`] = `
   <!-- Import Map URL: https://cdn.baseplate.cloud/convex/prod/test.importmap  -->
   <script type=\\"systemjs-importmap\\">
     {
-  \\"imports\\": {},
+  \\"imports\\": {
+    \\"single-spa\\": \\"https://cdn.jsdelivr.net/npm/single-spa@6.0.0/lib/es2015/system/single-spa.dev.min.js\\",
+    \\"single-spa-layout\\": \\"https://cdn.jsdelivr.net/npm/single-spa-layout@2.2.0/dist/system/single-spa-layout.min.js\\"
+  },
   \\"scopes\\": {}
 }
   </script>

--- a/src/handleIndexHtml.ts
+++ b/src/handleIndexHtml.ts
@@ -84,6 +84,14 @@ export async function handleIndexHtml(
       finalParams.pageInit.isEntryModule = true;
       break;
     case "single-spa":
+      importMap!.imports["single-spa"] = finalParams.importMap.isSystemJS
+        ? "https://cdn.jsdelivr.net/npm/single-spa@6.0.0/lib/es2015/system/single-spa.dev.min.js"
+        : "https://cdn.jsdelivr.net/npm/single-spa@6.0.0/lib/es2015/esm/single-spa.min.js";
+
+      importMap!.imports["single-spa-layout"] = finalParams.importMap.isSystemJS
+        ? "https://cdn.jsdelivr.net/npm/single-spa-layout@2.2.0/dist/system/single-spa-layout.min.js"
+        : "https://cdn.jsdelivr.net/npm/single-spa-layout@2.2.0/dist/esm/single-spa-layout.min.js";
+
       finalParams.pageInit.isSingleSpa = true;
       finalParams.pageInit.isEntryModule = false;
 


### PR DESCRIPTION
In order for [these imports](https://github.com/JustUtahCoders/baseplate-cloudflare-worker/blob/870e79c8abcf47c4ef86b494f085f1c978f18566/src/indexHtml.mustache#L49) to work within web apps, we need single-spa and single-spa-layout in the import map. Over time, this is something that will be managed within baseplate-web-app's shared dependencies feature. But for initial baseplate launch, I'm just hardcoding the latest versions of the libraries until we have time to build the shared dependencies feature