### PR TITLE
Skip invalid preloads rather than returning 500

### DIFF
--- a/.changeset/heavy-walls-promise.md
+++ b/.changeset/heavy-walls-promise.md
@@ -1,0 +1,5 @@
+---
+"baseplate-cloudflare-worker": patch
+---
+
+Skip invalid preloads in web apps rather than returning 500

--- a/src/handleIndexHtml.ts
+++ b/src/handleIndexHtml.ts
@@ -163,7 +163,7 @@ export async function handleIndexHtml(
   // Since browsers don't support import map specifiers in preload <link> elements,
   // we tell the browser to preload the full URL for the module, as found in the
   // import map
-  for (let preload of finalParams.preloads) {
+  for (let [index, preload] of finalParams.preloads.entries()) {
     if (preload.importSpecifier) {
       if (importMap?.imports[preload.importSpecifier]) {
         preload.href = importMap.imports[preload.importSpecifier];
@@ -173,7 +173,7 @@ export async function handleIndexHtml(
         console.error(
           `import specifier '${preload.importSpecifier}' cannot be preloaded because it doesn't exist in the import map`
         );
-        return internalErrorResponse(request, orgSettings);
+        finalParams.preloads.splice(index, 1);
       }
     }
   }

--- a/src/handleIndexHtml.ts
+++ b/src/handleIndexHtml.ts
@@ -173,6 +173,7 @@ export async function handleIndexHtml(
         console.error(
           `import specifier '${preload.importSpecifier}' cannot be preloaded because it doesn't exist in the import map`
         );
+        // Skip this preload, but still return the html file
         finalParams.preloads.splice(index, 1);
       }
     }


### PR DESCRIPTION
This avoids 500 errors when baseplate users specify a new microfrontend in the html template parameters that doesn't yet exist in the import map